### PR TITLE
Cohere API parameters default to server side defaults

### DIFF
--- a/libs/partners/cohere/langchain_cohere/chat_models.py
+++ b/libs/partners/cohere/langchain_cohere/chat_models.py
@@ -107,7 +107,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
             from langchain_cohere import ChatCohere
             from langchain_core.messages import HumanMessage
 
-            chat = ChatCohere(model="command", max_tokens=256, temperature=0.75)
+            chat = ChatCohere(cohere_api_key="my-api-key")
 
             messages = [HumanMessage(content="knock knock")]
             chat.invoke(messages)

--- a/libs/partners/cohere/langchain_cohere/chat_models.py
+++ b/libs/partners/cohere/langchain_cohere/chat_models.py
@@ -127,14 +127,16 @@ class ChatCohere(BaseChatModel, BaseCohere):
     @property
     def _default_params(self) -> Dict[str, Any]:
         """Get the default parameters for calling Cohere API."""
-        return {
+        base_params = {
+            "model": self.model,
             "temperature": self.temperature,
         }
+        return {k: v for k, v in base_params.items() if v is not None}
 
     @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
-        return {**{"model": self.model}, **self._default_params}
+        return self._default_params
 
     def _stream(
         self,

--- a/libs/partners/cohere/langchain_cohere/llms.py
+++ b/libs/partners/cohere/langchain_cohere/llms.py
@@ -55,7 +55,7 @@ class BaseCohere(Serializable):
     model: Optional[str] = Field(default=None)
     """Model name to use."""
 
-    temperature: float = 0.75
+    temperature: Optional[float] = None
     """A non-negative float that tunes the degree of randomness in generation."""
 
     cohere_api_key: Optional[SecretStr] = None
@@ -102,19 +102,19 @@ class Cohere(LLM, BaseCohere):
             cohere = Cohere(model="gptd-instruct-tft", cohere_api_key="my-api-key")
     """
 
-    max_tokens: int = 256
+    max_tokens: Optional[int] = None
     """Denotes the number of tokens to predict per generation."""
 
-    k: int = 0
+    k: Optional[int] = None
     """Number of most likely tokens to consider at each step."""
 
-    p: int = 1
+    p: Optional[int] = None
     """Total probability mass of tokens to consider at each step."""
 
-    frequency_penalty: float = 0.0
+    frequency_penalty: Optional[float] = None
     """Penalizes repeated tokens according to frequency. Between 0 and 1."""
 
-    presence_penalty: float = 0.0
+    presence_penalty: Optional[float] = None
     """Penalizes repeated tokens. Between 0 and 1."""
 
     truncate: Optional[str] = None
@@ -132,16 +132,17 @@ class Cohere(LLM, BaseCohere):
 
     @property
     def _default_params(self) -> Dict[str, Any]:
-        """Get the default parameters for calling Cohere API."""
-        return {
-            "max_tokens": self.max_tokens,
+        """Configurable parameters for calling Cohere's generate API."""
+        base_params = {
+            "model": self.model,
             "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
             "k": self.k,
             "p": self.p,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
-            "truncate": self.truncate,
         }
+        return {k: v for k, v in base_params.items() if v is not None}
 
     @property
     def lc_secrets(self) -> Dict[str, str]:
@@ -150,7 +151,7 @@ class Cohere(LLM, BaseCohere):
     @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
-        return {**{"model": self.model}, **self._default_params}
+        return self._default_params
 
     @property
     def _llm_type(self) -> str:

--- a/libs/partners/cohere/langchain_cohere/llms.py
+++ b/libs/partners/cohere/langchain_cohere/llms.py
@@ -99,7 +99,7 @@ class Cohere(LLM, BaseCohere):
 
             from langchain_cohere import Cohere
 
-            cohere = Cohere(model="gptd-instruct-tft", cohere_api_key="my-api-key")
+            cohere = Cohere(cohere_api_key="my-api-key")
     """
 
     max_tokens: Optional[int] = None

--- a/libs/partners/cohere/langchain_cohere/llms.py
+++ b/libs/partners/cohere/langchain_cohere/llms.py
@@ -141,6 +141,7 @@ class Cohere(LLM, BaseCohere):
             "p": self.p,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
+            "truncate": self.truncate,
         }
         return {k: v for k, v in base_params.items() if v is not None}
 

--- a/libs/partners/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/cohere/tests/unit_tests/test_chat_models.py
@@ -1,5 +1,7 @@
 """Test chat model integration."""
+import typing
 
+import pytest
 
 from langchain_cohere.chat_models import ChatCohere
 
@@ -7,3 +9,19 @@ from langchain_cohere.chat_models import ChatCohere
 def test_initialization() -> None:
     """Test chat model initialization."""
     ChatCohere(cohere_api_key="test")
+
+
+@pytest.mark.parametrize("chat_cohere,expected", [
+    pytest.param(ChatCohere(cohere_api_key="test"), {}, id="defaults"),
+    pytest.param(ChatCohere(
+        cohere_api_key="test",
+        model="foo",
+        temperature=1.0
+    ), {
+        "model": "foo",
+        "temperature": 1.0,
+    }, id="values are set")
+])
+def test_default_params(chat_cohere: ChatCohere, expected: typing.Dict):
+    actual = chat_cohere._default_params
+    assert expected == actual

--- a/libs/partners/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/cohere/tests/unit_tests/test_chat_models.py
@@ -25,6 +25,6 @@ def test_initialization() -> None:
         ),
     ],
 )
-def test_default_params(chat_cohere: ChatCohere, expected: typing.Dict):
+def test_default_params(chat_cohere: ChatCohere, expected: typing.Dict) -> None:
     actual = chat_cohere._default_params
     assert expected == actual

--- a/libs/partners/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/cohere/tests/unit_tests/test_chat_models.py
@@ -11,17 +11,20 @@ def test_initialization() -> None:
     ChatCohere(cohere_api_key="test")
 
 
-@pytest.mark.parametrize("chat_cohere,expected", [
-    pytest.param(ChatCohere(cohere_api_key="test"), {}, id="defaults"),
-    pytest.param(ChatCohere(
-        cohere_api_key="test",
-        model="foo",
-        temperature=1.0
-    ), {
-        "model": "foo",
-        "temperature": 1.0,
-    }, id="values are set")
-])
+@pytest.mark.parametrize(
+    "chat_cohere,expected",
+    [
+        pytest.param(ChatCohere(cohere_api_key="test"), {}, id="defaults"),
+        pytest.param(
+            ChatCohere(cohere_api_key="test", model="foo", temperature=1.0),
+            {
+                "model": "foo",
+                "temperature": 1.0,
+            },
+            id="values are set",
+        ),
+    ],
+)
 def test_default_params(chat_cohere: ChatCohere, expected: typing.Dict):
     actual = chat_cohere._default_params
     assert expected == actual

--- a/libs/partners/cohere/tests/unit_tests/test_llms.py
+++ b/libs/partners/cohere/tests/unit_tests/test_llms.py
@@ -17,31 +17,39 @@ def test_cohere_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(BaseCohere().cohere_api_key, SecretStr)
 
 
-@pytest.mark.parametrize("cohere,expected", [
-    pytest.param(Cohere(cohere_api_key="test"), {}, id="defaults"),
-    pytest.param(Cohere(
-        # the following are arbitrary testing values which shouldn't be used:
-        cohere_api_key="test",
-        model="foo",
-        temperature=0.1,
-        max_tokens=2,
-        k=3,
-        p=4,
-        frequency_penalty=0.5,
-        presence_penalty=0.6,
-    ), {
-        "model": "foo",
-        "temperature": 0.1,
-        "max_tokens": 2,
-        "k": 3,
-        "p": 4,
-        "frequency_penalty": 0.5,
-        "presence_penalty": 0.6,
-    }, id="with values set"),
-])
+@pytest.mark.parametrize(
+    "cohere,expected",
+    [
+        pytest.param(Cohere(cohere_api_key="test"), {}, id="defaults"),
+        pytest.param(
+            Cohere(
+                # the following are arbitrary testing values which shouldn't be used:
+                cohere_api_key="test",
+                model="foo",
+                temperature=0.1,
+                max_tokens=2,
+                k=3,
+                p=4,
+                frequency_penalty=0.5,
+                presence_penalty=0.6,
+            ),
+            {
+                "model": "foo",
+                "temperature": 0.1,
+                "max_tokens": 2,
+                "k": 3,
+                "p": 4,
+                "frequency_penalty": 0.5,
+                "presence_penalty": 0.6,
+            },
+            id="with values set",
+        ),
+    ],
+)
 def test_default_params(cohere: Cohere, expected: typing.Dict):
     actual = cohere._default_params
     assert expected == actual
+
 
 # def test_saving_loading_llm(tmp_path: Path) -> None:
 #     """Test saving/loading an Cohere LLM."""

--- a/libs/partners/cohere/tests/unit_tests/test_llms.py
+++ b/libs/partners/cohere/tests/unit_tests/test_llms.py
@@ -32,6 +32,7 @@ def test_cohere_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
                 p=4,
                 frequency_penalty=0.5,
                 presence_penalty=0.6,
+                truncate="START",
             ),
             {
                 "model": "foo",
@@ -41,6 +42,7 @@ def test_cohere_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
                 "p": 4,
                 "frequency_penalty": 0.5,
                 "presence_penalty": 0.6,
+                "truncate": "START",
             },
             id="with values set",
         ),

--- a/libs/partners/cohere/tests/unit_tests/test_llms.py
+++ b/libs/partners/cohere/tests/unit_tests/test_llms.py
@@ -48,7 +48,7 @@ def test_cohere_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     ],
 )
-def test_default_params(cohere: Cohere, expected: typing.Dict):
+def test_default_params(cohere: Cohere, expected: typing.Dict) -> None:
     actual = cohere._default_params
     assert expected == actual
 

--- a/libs/partners/cohere/tests/unit_tests/test_llms.py
+++ b/libs/partners/cohere/tests/unit_tests/test_llms.py
@@ -1,13 +1,13 @@
 """Test Cohere API wrapper."""
+import typing
 
-
+import pytest
 from langchain_core.pydantic_v1 import SecretStr
-from pytest import MonkeyPatch
 
-from langchain_cohere.llms import BaseCohere
+from langchain_cohere.llms import BaseCohere, Cohere
 
 
-def test_cohere_api_key(monkeypatch: MonkeyPatch) -> None:
+def test_cohere_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that cohere api key is a secret key."""
     # test initialization from init
     assert isinstance(BaseCohere(cohere_api_key="1").cohere_api_key, SecretStr)
@@ -16,6 +16,32 @@ def test_cohere_api_key(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("COHERE_API_KEY", "secret-api-key")
     assert isinstance(BaseCohere().cohere_api_key, SecretStr)
 
+
+@pytest.mark.parametrize("cohere,expected", [
+    pytest.param(Cohere(cohere_api_key="test"), {}, id="defaults"),
+    pytest.param(Cohere(
+        # the following are arbitrary testing values which shouldn't be used:
+        cohere_api_key="test",
+        model="foo",
+        temperature=0.1,
+        max_tokens=2,
+        k=3,
+        p=4,
+        frequency_penalty=0.5,
+        presence_penalty=0.6,
+    ), {
+        "model": "foo",
+        "temperature": 0.1,
+        "max_tokens": 2,
+        "k": 3,
+        "p": 4,
+        "frequency_penalty": 0.5,
+        "presence_penalty": 0.6,
+    }, id="with values set"),
+])
+def test_default_params(cohere: Cohere, expected: typing.Dict):
+    actual = cohere._default_params
+    assert expected == actual
 
 # def test_saving_loading_llm(tmp_path: Path) -> None:
 #     """Test saving/loading an Cohere LLM."""


### PR DESCRIPTION
We'd like to default to the server side values of API parameters such as `temperature` and `max_tokens`. This PR makes the parameters optional and only includes them in the request when they've been explicitly set to a non-default value.

It also fixes an issue where `model=` seemingly wasn't passed to the API.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
